### PR TITLE
Add CI jobs to collator template

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,19 @@
+name: Check Links
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^https://crates.io"
+        }
+    ]
+}

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,0 +1,47 @@
+name: Test Code
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  test-code:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+
+      # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly-2020-05-07
+        components: rustfmt, clippy
+        target: wasm32-unknown-unknown
+        override: true
+        default: true
+
+    # Enable this for clippy linting.
+    # - name: Check and Lint Code
+    #   run: cargo +nightly-2020-05-07 clippy -- -D warnings
+
+    - name: Check Code
+      run: cargo check --all
+
+    - name: Test Code
+      run: cargo test --all


### PR DESCRIPTION
This PR adds github actions-based ci jobs. It is currently just a few simple things like `cargo test` and checking links in md docs. I just want to scaffold this so that we can add stuff like docker images later if desired.